### PR TITLE
Rommel layco remove boto3 from exoscale 0.8.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,5 +35,6 @@ serve:
 
 installrequirements:
 	@pip install wheel
-	@pip install -r requirements.dev.txt
+	@pip install .
+	@pip install '.[dev]'
 	@pip install -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 ]
 dependencies = [
     "attrs>=20.1.0",
-    "boto3>=1.9.176",
     "cs>=2.7.1",
     "requests-exoscale-auth>=1.1.2",
     "requests>=2.22.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,3 @@
 [pytest]
 timeout = 300
-filterwarnings =
-    # https://github.com/boto/boto3/issues/1615
-    ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working:DeprecationWarning
+


### PR DESCRIPTION
remove boto3 from exoscale.

We use a patch version o botocore https://github.com/aiven/botocore/tree/aiven-1.29.111. This means we need to support multiple versions of botocore.

Instead we should remove boto3 and use botocore, so we only need one version of botocore. The `put_file` method is not used so is safe to remove 